### PR TITLE
Fix external links being hijacked by VitePress router

### DIFF
--- a/.vitepress/config/index.mts
+++ b/.vitepress/config/index.mts
@@ -26,7 +26,10 @@ export default withMermaid({
     themeConfig: {
       // https://vitepress.dev/reference/default-theme-config
 
-      logoLink: 'https://www.emqx.com/en/mqtt-for-ai',
+      logoLink: {
+        link: 'https://www.emqx.com/en/mqtt-for-ai',
+        rel: 'external',
+      },
 
       notFound: {
         linkText: 'Go to Homepage',

--- a/.vitepress/theme/components/NotFound.vue
+++ b/.vitepress/theme/components/NotFound.vue
@@ -23,6 +23,7 @@ const link = (notFound as { link?: string }).link ?? '/'
         class="link"
         :href="link"
         :aria-label="linkLabel"
+        rel="external"
       >
         {{ linkText }}
       </a>


### PR DESCRIPTION
Add rel="external" to logoLink and 404 page link to prevent
VitePress SPA navigation from intercepting external URLs.