### PR TITLE
Override VPNavBarTitle to fix external link navigation

### DIFF
--- a/.vitepress/config/index.mts
+++ b/.vitepress/config/index.mts
@@ -1,3 +1,4 @@
+import { fileURLToPath, URL } from 'node:url'
 import { defineConfig } from 'vitepress'
 import { withMermaid } from 'vitepress-plugin-mermaid'
 import tailwindcss from '@tailwindcss/vite'
@@ -15,6 +16,16 @@ export default withMermaid({
 
     vite: {
       plugins: [tailwindcss()],
+      resolve: {
+        alias: [
+          {
+            find: /^.*\/VPNavBarTitle\.vue$/,
+            replacement: fileURLToPath(
+              new URL('../theme/components/NavBarTitle.vue', import.meta.url)
+            ),
+          },
+        ],
+      },
     },
 
     sitemap: {
@@ -26,10 +37,7 @@ export default withMermaid({
     themeConfig: {
       // https://vitepress.dev/reference/default-theme-config
 
-      logoLink: {
-        link: 'https://www.emqx.com/en/mqtt-for-ai',
-        rel: 'external',
-      },
+      logoLink: 'https://www.emqx.com/en/mqtt-for-ai',
 
       notFound: {
         linkText: 'Go to Homepage',

--- a/.vitepress/theme/components/NavBarTitle.vue
+++ b/.vitepress/theme/components/NavBarTitle.vue
@@ -1,0 +1,57 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useData } from 'vitepress'
+import VPImage from 'vitepress/dist/client/theme-default/components/VPImage.vue'
+
+const { site, theme } = useData()
+
+const link = computed(() =>
+  typeof theme.value.logoLink === 'string'
+    ? theme.value.logoLink
+    : (theme.value.logoLink as { link?: string })?.link
+)
+
+const isExternal = computed(() => link.value?.startsWith('http'))
+</script>
+
+<template>
+  <div class="VPNavBarTitle" :class="{ 'vp-raw': isExternal }">
+    <a
+      class="title"
+      :href="link ?? '/'"
+    >
+      <VPImage v-if="theme.logo" class="logo" :image="theme.logo" />
+      <span v-if="theme.siteTitle">{{ theme.siteTitle }}</span>
+      <span v-else-if="theme.siteTitle === undefined">{{ site.title }}</span>
+    </a>
+  </div>
+</template>
+
+<style scoped>
+.title {
+  display: flex;
+  align-items: center;
+  border-bottom: 1px solid transparent;
+  width: 100%;
+  height: var(--vp-nav-height);
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--vp-c-text-1);
+  transition: opacity 0.25s;
+}
+
+@media (min-width: 960px) {
+  .title {
+    flex-shrink: 0;
+  }
+
+  .VPNavBarTitle.has-sidebar .title {
+    border-bottom-color: var(--vp-c-divider);
+  }
+}
+
+:deep(.logo) {
+  margin-right: 8px;
+  height: var(--vp-nav-logo-height);
+}
+</style>

--- a/.vitepress/theme/components/NotFound.vue
+++ b/.vitepress/theme/components/NotFound.vue
@@ -18,12 +18,11 @@ const link = (notFound as { link?: string }).link ?? '/'
     <h1 class="title">{{ title }}</h1>
     <div class="divider" />
     <blockquote class="quote">{{ quote }}</blockquote>
-    <div class="action">
+    <div class="action vp-raw">
       <a
         class="link"
         :href="link"
         :aria-label="linkLabel"
-        rel="external"
       >
         {{ linkText }}
       </a>


### PR DESCRIPTION
Use Vite alias to replace default VPNavBarTitle component with
custom implementation that adds vp-raw class for external links,
preventing VitePress router from hijacking the navigation.